### PR TITLE
atopile 0.3.16

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -61,6 +61,6 @@ class Atopile < Formula
 
     output = shell_output("#{bin}/ato --non-interactive build --standalone example.ato:Example 2>&1", 0)
     assert_match "Build successful! 🚀", output
-    assert_predicate testpath/"standalone/default/default.kicad_pcb", :exist?
+    assert_path_exists testpath/"standalone/default/default.kicad_pcb"
   end
 end


### PR DESCRIPTION
- bump version to 0.3.16
- installs from pre-built wheel instead of sdist

TODO:
- [x] re-add a real test

Requires: https://github.com/atopile/atopile/pull/961