### PR TITLE
atopile 0.5.0

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.4.1"
+  version "0.5.0"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/82/fb/1b4a7ecad983c122a7cce7b7a9bd34abc6988646dd803b319377a6ee28b1/atopile-0.4.1-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "5b5c106053e2ec805d6273af95810568b9fdab5c6d1a039c023fce770d35194a"
+      url "https://files.pythonhosted.org/packages/f9/66/6247c2c163321416db6dac404efcffb91ed9a595df1fab42b746a53dab13/atopile-0.5.0-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "87f11af6bb3ee7c1a38753f00487305b156cffa0103b71dfbe2d4dd11c1f9a25"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.4.1-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.5.0-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/15/00/f6839639f613b7fc64c2e8ebe9dccc6edae4cca1ad6aa4796dc5674e8568/atopile-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "4d4309b9feb5aefb7695a4713ba84f63ab9feaafd30d36390f58bbd0b1e93c9c"
+      url "https://files.pythonhosted.org/packages/cd/3b/d81715c110bb71adf33df676628c72a0db4e8c9bf68bf639fb7b9af015c7/atopile-0.5.0-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "bd201c7fba73a7e2793a6785c2fb596829c57556a759eee22d4c36e1da5568c4"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.5.0-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/7c/40/1181134e5e6abd88dcfd7a84ad9f298fdbaaa57bdb6115960c17c50428dc/atopile-0.4.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "c29da3df759b6905f7ebffb92a429e2473adf4454889c497aff322efadb9e939"
+      url "https://files.pythonhosted.org/packages/18/d5/ca694dc2a80fcf49199bfff17d0d5d1f7be3895fa2e11ec94780be274793/atopile-0.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "d924359faaa3f9ad3025e0e9e888d96f77348b11f11c9eff431b2369bbcb0639"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.4.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.5.0.

  This update was automatically triggered by the release workflow.