### PR TITLE
Fix auto-merge workflow missing checkout

### DIFF
--- a/.github/workflows/merge-formula-update.yml
+++ b/.github/workflows/merge-formula-update.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains( github.event.pull_request.labels.*.name, 'bump-formula') }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Enable auto-merge
         run: gh pr merge --auto --squash ${{ github.event.pull_request.number }}
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for handling formula update pull requests. The most important change is the addition of a step to check out the repository before enabling auto-merge.

Workflow updates:

* [`.github/workflows/merge-formula-update.yml`](diffhunk://#diff-7234c48018cd335ab2bc29e9eac4b84cb5d8c9c533f271a197a33b8c968a07b2R16-R17): Added a `uses: actions/checkout@v4` step to ensure the repository is checked out before running the auto-merge command.