### PR TITLE
atopile 0.6.0

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.5.1"
+  version "0.6.0"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/2c/01/8b8f835b66ba7f6c3bc7219bdd05a988f54bd79b6a7d6b0202278ee70b83/atopile-0.5.1-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "e01f5569b4c4e8a2554d2d6b99516011b387558f84f7d96f130fd51865123db1"
+      url "https://files.pythonhosted.org/packages/2f/98/a8702551368b735a18150eaab43fff98e79175c46f29e4be78dac5672440/atopile-0.6.0-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "c3931b393edc655f2983eed9681e96fbb0bfc1255936333f25f2903e08b5ae0a"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.5.1-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.6.0-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/b3/77/d84d05a291faa9d625cab235fb11ad727628a1d751ddabc7fb5665d36923/atopile-0.5.1-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "70b1b5b820d88b557b752b2fc85bf596f23d946f9b7e592c10f003f0b5fdf6c4"
+      url "https://files.pythonhosted.org/packages/9e/d8/1a1d6731d56ee564f242c39880d6001fede84092bcc2342e973e364ad87c/atopile-0.6.0-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "46e343e42d4909f455ee952e4336cb1816d1ab0c6cc0541ed86587c94e80a6c9"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.5.1-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.6.0-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/6e/19/139718e6b326e534a6aad55589333cf34192aaee55becd55c3a1659b1eda/atopile-0.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "be13edb929145bfdaaaf8900e66d0946fd237d34c9e3d88b159cadf248b60511"
+      url "https://files.pythonhosted.org/packages/72/6e/6b2f9372f133c703ac7324929d93ea010b400600dc29c86b1dae1452febf/atopile-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "e7fbedc8881b28f48a69c3c2a4df5b0c6e52840852f9dd422a8985f98c7b905d"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.6.0.

  This update was automatically triggered by the release workflow.