### PR TITLE
atopile 0.8.1

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.7.0"
+  version "0.8.1"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/d6/9f/656e9090e75945b60ac6f5d2299987e6e42b4277627770822399ebb0bf36/atopile-0.7.0-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "705b30cfd48f3d56e2058880afd484e57ee8f719526826d67e617968f2d712c0"
+      url "https://files.pythonhosted.org/packages/e5/21/2581c680b2aad2aa94a7c006ce86a8be49d8835c9a90212e1464f1889d78/atopile-0.8.1-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "563ef27a33383012c692ec2234b53f5eddd2b7d478a9f05ce307b215ea90ad6c"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.7.0-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.8.1-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/4f/08/667b030374ec59f803fff0587117416d9a4fb2227a2ae594c33b1261cb75/atopile-0.7.0-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "379ed867f9535d7d36adf786d9ead90d3f127307d13837a2c92e2f32f21767a8"
+      url "https://files.pythonhosted.org/packages/2e/6c/e4fa88e524ff265fac76b4bac43667daffd6196eea59a86ca9571a454c95/atopile-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "0c7e816362bd38ac6b350727f24cb3258fb945c199278be73b77d4791b87fbd7"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.7.0-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/30/0c/29233f6c5ed330d555f907b224e7381eacab0a4ccff35fdab9fab2dfc71e/atopile-0.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "7d6b74c2017ee9d093e9e4e2f41eeddeb0befbdc0df8a8bcd06dd4f04760cd52"
+      url "https://files.pythonhosted.org/packages/65/71/fa74f51936fa854d883b07055af7d97bc77e9cdb08ad12e2e12a47110cdb/atopile-0.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "c64a41203abdbba01b5fd2cb72f6bda88d9d736ee649ccb679c45662566ae3b4"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.8.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.8.1.

  This update was automatically triggered by the release workflow.