### PR TITLE
atopile 0.9.0

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.8.2"
+  version "0.9.0"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/96/d6/e24398406af2e8b8867846431328f4b420c4c305dacf2e3f5e76a9b4da17/atopile-0.8.2-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "de6fcd117cd8c73048e0bc2618e2de8922c40a6cb67908139999f65e21938e09"
+      url "https://files.pythonhosted.org/packages/0b/9e/2f411791cc9c15ed590d397411faa12adccdd106698db9addb98e52c702b/atopile-0.9.0-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "69093ccb11691418a60e8876ae2be9e2847d2f2537c5cb3707e89b8e146ad1b6"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.8.2-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.9.0-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/f9/53/a17477ff0b7315fcf2e43c58a0e536902ab392a9b514667964014e68b1ac/atopile-0.8.2-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "5bf6e273963631d2827701b690b8a1d09ed209e0980d1f9826850a2e362c3040"
+      url "https://files.pythonhosted.org/packages/0a/04/61d8c485caf863ab9ff62defc7933eb5f245efe9c2aa94b867e039d361c4/atopile-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "a0c8be6ecd3dff7e4c9f589c0c66247ab331b47935c7442cedeccf2f12879331"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.8.2-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/dc/6d/f7a6a1f42122ad2735c24da27d7fed6105b2fcfc468f98e2ba9012942a62/atopile-0.8.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "8702fb3340058b991e37349d22b16eee99c97441076b8d23225c8d32763ed238"
+      url "https://files.pythonhosted.org/packages/1e/a0/7c141d967c8a45fe1be492431f1707debdd84a9e5ae8ebff174e91beee2e/atopile-0.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "21f8e40bee22e0dc4ae8d1c10597e33a3a02fc8cf92c269d29f3db257a435167"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.8.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.9.0.

  This update was automatically triggered by the release workflow.