### PR TITLE
atopile 0.9.2

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.9.1"
+  version "0.9.2"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/b1/73/f65b713cb21785a60a2e78d0c93e31d83b5a795bb81521fc7f3b5ddf14e1/atopile-0.9.1-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "fd1549663a1ff6bbc331159799a209e9f95a5ac562ae8a7037464e05963c6c61"
+      url "https://files.pythonhosted.org/packages/db/46/0990fdf15c13923a10909c464ff1d7471522b9e4e1d9a7adffba607467c1/atopile-0.9.2-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "8b4fab994b629966b0438462d3c3cb1ec7d4dc16d01cf41167fa8e7474b91c96"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.1-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.9.2-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/0c/50/bd9a3de5a8fbb3e7ee060fd4953606b06b843afab9ae7107a61b93950432/atopile-0.9.1-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "1b39f52a9d894b604b6f816d8cd7517e92711d020de0b2eaa87ce2c46431eb05"
+      url "https://files.pythonhosted.org/packages/cc/80/aa02837fc4b7ef986c53b032ef5e98c02738d767d3b312290e21eb6bd780/atopile-0.9.2-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "f9da00d7325f4c7bfb27a75364aa04e22219a097978574b46b53cd35120f3725"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.1-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.9.2-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/30/a8/0f5da08a1426614b53975882d398222ed8da6c35008ccc65ed28d65d940d/atopile-0.9.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "549f9f6bb36900c9e86b7fea66cd390510d7382a94a73f5b5b6a272f3be5d399"
+      url "https://files.pythonhosted.org/packages/54/aa/aac0ea1467624fe10a13aeb29bdc51d1e7b85a9c7a5ac9462eef8d5de354/atopile-0.9.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "fca5bf283e2bb52de7068f5d8222c11bbe45f7247b271f8b644db6582f5b9cec"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.9.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.9.2.

  This update was automatically triggered by the release workflow.