### PR TITLE
atopile 0.9.5

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.9.2"
+  version "0.9.5"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/db/46/0990fdf15c13923a10909c464ff1d7471522b9e4e1d9a7adffba607467c1/atopile-0.9.2-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "8b4fab994b629966b0438462d3c3cb1ec7d4dc16d01cf41167fa8e7474b91c96"
+      url "https://files.pythonhosted.org/packages/98/e6/d1c512f279bd2226b2b59116ccabeb9478ec93fb711bc8feda85618c9c5b/atopile-0.9.5-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "981b43aa1b6826bd3f386f29f968fbef7ce17bfb108c9a65dffeaca1a4b6c2f7"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.2-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.9.5-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/cc/80/aa02837fc4b7ef986c53b032ef5e98c02738d767d3b312290e21eb6bd780/atopile-0.9.2-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "f9da00d7325f4c7bfb27a75364aa04e22219a097978574b46b53cd35120f3725"
+      url "https://files.pythonhosted.org/packages/5b/f3/227ffb15b00e20e4a644c2ac9033b203fae138d25dbae6e7bc97b349d014/atopile-0.9.5-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "87a9ae18c508a3b29a0739e58a9cd2c5f615b2a9a5a7e5a063c40276da621cf7"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.2-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.9.5-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/54/aa/aac0ea1467624fe10a13aeb29bdc51d1e7b85a9c7a5ac9462eef8d5de354/atopile-0.9.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "fca5bf283e2bb52de7068f5d8222c11bbe45f7247b271f8b644db6582f5b9cec"
+      url "https://files.pythonhosted.org/packages/ce/e4/7f7666dbf2c6651c823b3c08f8b49885bf68c0f65a2bc8dd9c124e61c4f6/atopile-0.9.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "40f7120f8769ab0168d18f4752f1a494d6549cb00a31e685f71a673076783e22"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.9.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.9.5.

  This update was automatically triggered by the release workflow.