### PR TITLE
atopile 0.9.7

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.9.5"
+  version "0.9.7"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/98/e6/d1c512f279bd2226b2b59116ccabeb9478ec93fb711bc8feda85618c9c5b/atopile-0.9.5-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "981b43aa1b6826bd3f386f29f968fbef7ce17bfb108c9a65dffeaca1a4b6c2f7"
+      url "https://files.pythonhosted.org/packages/2f/a4/21ad6b43a611f80069ee1103eabd4a7f5dc00ab7bb0ea47b06b24aa0916f/atopile-0.9.7-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "5264104c0ad7a749cbf99915ce685f52abfe034b0f81c7e39bc46d08c1d0fb31"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.5-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.9.7-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/5b/f3/227ffb15b00e20e4a644c2ac9033b203fae138d25dbae6e7bc97b349d014/atopile-0.9.5-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "87a9ae18c508a3b29a0739e58a9cd2c5f615b2a9a5a7e5a063c40276da621cf7"
+      url "https://files.pythonhosted.org/packages/17/6b/e38ce1cb8624997d7b1b539c4e788fcf0a7dceee2931cb50e21855535d9b/atopile-0.9.7-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "31c52a7f2333c0d715f1830ab7c586beb806da241dde9501de6ae4d17292ae85"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.5-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.9.7-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/ce/e4/7f7666dbf2c6651c823b3c08f8b49885bf68c0f65a2bc8dd9c124e61c4f6/atopile-0.9.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "40f7120f8769ab0168d18f4752f1a494d6549cb00a31e685f71a673076783e22"
+      url "https://files.pythonhosted.org/packages/73/ac/5e85112411b05d6aacf5d4961ffbc7ddd3193b6cac80d97f4339eb104e75/atopile-0.9.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "0f3dbba7c152e0a31a3859c55320807287687878a5e2aa38b8f55a6b48d9a265"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.9.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.9.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.9.7.

  This update was automatically triggered by the release workflow.