### PR TITLE
atopile 0.10.5

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.10.3"
+  version "0.10.5"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/a8/b9/f918f11aedf667be90d04254ee8ca6aed0f10f51745eac9dd7dcee94f935/atopile-0.10.3-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "d66034804149761ffa1e84d688840094b62e259cf24958e864bb1eed061b83cf"
+      url "https://files.pythonhosted.org/packages/59/b2/a3a28422ceaa9e94639b36158d2573dd71b9e2432b8918bb983206b504ca/atopile-0.10.5-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "c45730791aa449b81a88923761ed23d71838e963fc3e5b4c9385e4371d91270a"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.3-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.10.5-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/96/6f/eb194d97af6c45689bcfbd30439c28d003c9efbf0cb4c9d893a5a3754637/atopile-0.10.3-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "e2284937ece8f37dd7c0d64b11827d11666515779fd9ca927740afbf4d69deb4"
+      url "https://files.pythonhosted.org/packages/81/66/272c94b3d8764d1d52efce2f25dfa16f6e5f316fa3cb1fa13ebabbdace2f/atopile-0.10.5-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "b5ea5fb2994c97524b17a0f33cad8de7467482b19d0738929457c87fe824e58a"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.3-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.10.5-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/64/ca/ca1bd045ebd1f17eb79596b7c2271b0afb21da4e072ce1053bbd1676abd1/atopile-0.10.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "218a9c6ae93f0f78c66cc6d55250fb8760be895c2676ca1f923e247dbc36b368"
+      url "https://files.pythonhosted.org/packages/34/6a/9fa41b8519410c2aaaf58f34ecb72edd466fa7998a700f50ba8487a6b4c1/atopile-0.10.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "26f9be88022012cebbd1e1f3216ad3c3b4030f69b218ca915744780c3fe8f3cb"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.10.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.10.5.

  This update was automatically triggered by the release workflow.