### PR TITLE
atopile 0.10.6

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.10.5"
+  version "0.10.6"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/59/b2/a3a28422ceaa9e94639b36158d2573dd71b9e2432b8918bb983206b504ca/atopile-0.10.5-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "c45730791aa449b81a88923761ed23d71838e963fc3e5b4c9385e4371d91270a"
+      url "https://files.pythonhosted.org/packages/16/ed/49732eeffe9ccc3fb4643f8238ef98bec00d9285d1c7403fc8ccb4e658b3/atopile-0.10.6-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "7a6ec984038b53ef772ce85fa310d9b4466d2a60de44422a9e96d96de5f3bf82"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.5-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.10.6-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/81/66/272c94b3d8764d1d52efce2f25dfa16f6e5f316fa3cb1fa13ebabbdace2f/atopile-0.10.5-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "b5ea5fb2994c97524b17a0f33cad8de7467482b19d0738929457c87fe824e58a"
+      url "https://files.pythonhosted.org/packages/b4/1d/99ada374feeee0148b75f3b86f3ad55d2a46e067780551a41a8b26afb2f0/atopile-0.10.6-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "fb77bbc2bc57eb97d5763824db4ead4dd2a8e7b76e7a00ba18b674441b8a69b2"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.5-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.10.6-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/34/6a/9fa41b8519410c2aaaf58f34ecb72edd466fa7998a700f50ba8487a6b4c1/atopile-0.10.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "26f9be88022012cebbd1e1f3216ad3c3b4030f69b218ca915744780c3fe8f3cb"
+      url "https://files.pythonhosted.org/packages/9e/18/c33d3c7954e800436ec07b9656c96d948c70d5347c4b3b7bbbf7699bc0c4/atopile-0.10.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "6fcc168e41231665a8d86e1b149b085a5e4828f34796291cae0dacff17d4935e"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.10.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.10.6.

  This update was automatically triggered by the release workflow.