### PR TITLE
atopile 0.10.8

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.10.7"
+  version "0.10.8"
   license "MIT"
 
   depends_on "python@3.13"
@@ -11,24 +11,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/95/14/573bf97a0ca173b4b72d81f0c19eacd51a01098aee1bad47cfdfe76bcf44/atopile-0.10.7-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "12cee68d5dc631a10198e903c61197d80dbc519ebe3dc98347fbad048d7925a4"
+      url "https://files.pythonhosted.org/packages/51/41/82c7e27f264e1261b834d87ffacf2b45583ad0b996f11c6d817ff90ea041/atopile-0.10.8-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "bcb3147797845a3c6448e0b35052271349291ff86378db0fc08cddf704b699dc"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.7-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.10.8-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/13/bf/d533dd99bea3750d21e055dbb7b3e35bb06b64c407a18909fce17bd24728/atopile-0.10.7-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "3ffb8d27b0c0643791a8fd1c444df6b022368b92d8004f077136dbfd09730df1"
+      url "https://files.pythonhosted.org/packages/89/0a/f7191140dd87418e026253ad2b7d87864fdd84be2db8b3568ec6e6b49fe8/atopile-0.10.8-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "a496b03e2e641481eced3029e1f2a6f3b5673878b411bb97b6d010c2034179f3"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.7-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.10.8-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -36,13 +36,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/0d/69/dd9e475939d1516bf421da0ae7bc2a5d4dc78c4bb20aeafee2d81174820f/atopile-0.10.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "ddcda5a5733edb011eac4cd39c133a3ad2bb124ff2d65f2ce9490885edfbe781"
+      url "https://files.pythonhosted.org/packages/23/e7/4fd9febecbb732fafb6b0ab5ad2a6b84be06c7d29fd30df71f706cf86cdf/atopile-0.10.8-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "8c37b8c36aa4840e3f918c9cb69f062a442f94537eba23ec1aac589fbaf21d77"
 
       def install
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.10.8-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.10.8.

  This update was automatically triggered by the release workflow.