### PR TITLE
atopile 0.10.11

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -6,6 +6,8 @@ class Atopile < Formula
   version "0.10.11"
   license "MIT"
 
+  depends_on "numpy"
+  depends_on "openblas"
   depends_on "python@3.13"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.10.11.

  This update was automatically triggered by the release workflow.