### PR TITLE
atopile 0.10.12

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.10.11"
+  version "0.10.12"
   license "MIT"
 
   depends_on "numpy"
@@ -13,24 +13,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/b5/26/fac101709a732f3980e3637c5785665f32e4e4b70b09baef1fe45ca5c626/atopile-0.10.11-cp313-cp313-macosx_11_0_arm64.whl"
-      sha256 "3f08f1d0ba1b467dd8858953168a884267a25689420f48f3977c91d808cb6bce"
+      url "https://files.pythonhosted.org/packages/67/91/e9643c635cf9a3c9c336a8b0f51e16d8a16c929ce95022f2a04e2899fca9/atopile-0.10.12-cp313-cp313-macosx_11_0_arm64.whl"
+      sha256 "d9fbc172d553d9b04521e02439d0a3de9cd3891fa620698f5dbe0a5a5aad5864"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.11-cp313-cp313-macosx_11_0_arm64.whl"
+          "#{buildpath}/atopile-0.10.12-cp313-cp313-macosx_11_0_arm64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/49/e9/8cfc9cbe21bf320cf7bd5fd102f4c85e0a196bcb6dd8ab6d683b2fa00072/atopile-0.10.11-cp313-cp313-macosx_10_13_x86_64.whl"
-      sha256 "ef389ffeee4996d2bb401d3aa199016f7f498adbd286ac0415bb8eefd7e7b2a7"
+      url "https://files.pythonhosted.org/packages/66/dd/d55ee808a38d5011961fd84ecab5d6848ed34b38fc0c2a8e9936e1180b21/atopile-0.10.12-cp313-cp313-macosx_10_13_x86_64.whl"
+      sha256 "75e48e7bf93e4967113ee8d6555b62f041691e6b60bfa2f6d640408be4a24723"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.11-cp313-cp313-macosx_10_13_x86_64.whl"
+          "#{buildpath}/atopile-0.10.12-cp313-cp313-macosx_10_13_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end
@@ -38,13 +38,13 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/ff/bd/75c47c91def8168f1f3685359dec46f8eaa2734c447e8c568463ec303491/atopile-0.10.11-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "f3d4172ff6a6babb8e120943522cfa65967378e309ff20587f5993f7485c5489"
+      url "https://files.pythonhosted.org/packages/d5/7f/2fbb4fd0266084d9bd920908843ab57b8dc7540353c041f82d928784264f/atopile-0.10.12-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "78f301ca29963978d9eb2e08b7d9e83040232f6d37fef45b48ec87e44a867fa4"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
         system "#{libexec}/bin/python", "-m", "pip", "install", \
-          "#{buildpath}/atopile-0.10.11-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+          "#{buildpath}/atopile-0.10.12-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         bin.install "#{libexec}/bin/ato"
       end
     end


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.10.12.

  This update was automatically triggered by the release workflow.