### PR TITLE
atopile 0.15.5

### DIFF
--- a/Formula/atopile.rb
+++ b/Formula/atopile.rb
@@ -3,7 +3,7 @@ class Atopile < Formula
 
   desc "Design circuit boards with code"
   homepage "https://atopile.io"
-  version "0.15.4"
+  version "0.15.5"
   license "MIT"
 
   depends_on "numpy"
@@ -13,24 +13,24 @@ class Atopile < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://files.pythonhosted.org/packages/d2/8d/5b08afcebf852c7e5f43c2bd18d0d410cb550741b1f1d64dc9ce25dfec62/atopile-0.15.4-cp314-cp314-macosx_11_0_arm64.whl"
-      sha256 "78092460e80bb47163af3c41313acd9da9195a409caae8d58ad68598ff7a7b4b"
+      url "https://files.pythonhosted.org/packages/c5/2b/7f2207f47c51e0f5ac91f8ea3f33687aca242b504ddce5876039027bd3ca/atopile-0.15.5-cp314-cp314-macosx_11_0_arm64.whl"
+      sha256 "9cfc604869c88f11ce22c111b590be673062f6462feb8c37746739a8ee146077"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
-        whl = "atopile-0.15.4-cp314-cp314-macosx_11_0_arm64.whl"
+        whl = "atopile-0.15.5-cp314-cp314-macosx_11_0_arm64.whl"
         system "#{libexec}/bin/python", "-m", "pip", "install",
           "#{buildpath}/#{whl}"
         bin.install "#{libexec}/bin/ato"
       end
     end
     if Hardware::CPU.intel?
-      url "https://files.pythonhosted.org/packages/5f/27/550f99bc20f72d21c4a12f77dc3df9b927abfb47e858f18eb51cae472e9b/atopile-0.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
-      sha256 "af818229247f23b134236ba195056f73c8857d1433c170345f175934ca569273"
+      url "https://files.pythonhosted.org/packages/b6/38/57effc5cdd109b26523d58ba929010c80cdfafe09c276e3e7c5f5a56e383/atopile-0.15.5-cp314-cp314-macosx_10_15_x86_64.whl"
+      sha256 "e79c10246a0712eda775801ebcbdaed675c2092757823a9478d1f8f5f670dd8b"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
-        whl = "atopile-0.15.4-cp314-cp314-macosx_10_15_x86_64.whl"
+        whl = "atopile-0.15.5-cp314-cp314-macosx_10_15_x86_64.whl"
         system "#{libexec}/bin/python", "-m", "pip", "install",
           "#{buildpath}/#{whl}"
         bin.install "#{libexec}/bin/ato"
@@ -40,12 +40,12 @@ class Atopile < Formula
 
   on_linux do
     if Hardware::CPU.is_64_bit?
-      url "https://files.pythonhosted.org/packages/91/7a/85a351bfc511e8ac833c90082c85ac8c3e5e56c9983ce6fe7689b30e766b/atopile-0.15.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-      sha256 "12be5f091467b5cfb536550d06fe4cde8b8274c375bd23a4c0b0a8b88b1a7ae4"
+      url "https://files.pythonhosted.org/packages/38/1b/e3448177015f520ad9fd012ec19351036b82e8b906d49f14390a515e2a7a/atopile-0.15.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+      sha256 "7d471d62f0d5fc54630d0c194d3f14ece1d4dbda2b3c1f5169b6f86bfb8fe09c"
 
       define_method(:install) do
         virtualenv_create(libexec, "python3")
-        whl = "atopile-0.15.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+        whl = "atopile-0.15.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
         system "#{libexec}/bin/python", "-m", "pip", "install",
           "#{buildpath}/#{whl}"
         bin.install "#{libexec}/bin/ato"


### PR DESCRIPTION
This PR updates the `atopile` formula to version 0.15.5.

  This update was automatically triggered by the release workflow.